### PR TITLE
Add more GCMD keywords to exceedance limits dataset

### DIFF
--- a/notebooks/exceedence_limits.ipynb
+++ b/notebooks/exceedence_limits.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,18 +143,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "SyntaxError",
-     "evalue": "invalid syntax. Perhaps you forgot a comma? (1935460626.py, line 6)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;36m  Cell \u001b[0;32mIn[16], line 6\u001b[0;36m\u001b[0m\n\u001b[0;31m    summary_no=\"Overskridelser av tålegrenser for forsuring (vann) med SSWCoaa- or FABoaa-modellene og eutrofiering (vegetasjon og vann) med empiriske tålegrenser\"\u001b[0m\n\u001b[0m               ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax. Perhaps you forgot a comma?\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ds.attrs = asdict(\n",
     "    DatasetAttrsGrid(\n",
@@ -167,6 +158,9 @@
     "            [\n",
     "                \"GCMDSK:EARTH SCIENCE > LAND SURFACE > SOILS > NITROGEN\",\n",
     "                \"GCMDSK:EARTH SCIENCE > LAND SURFACE > SOILS > SULFUR\",\n",
+    "                \"GCMDSK:EARTH SCIENCE > TERRESTRIAL HYDROSPHERE > WATER QUALITY/WATER CHEMISTRY > CONTAMINANTS > ACID RAIN\",\n",
+    "                \"GCMDSK:EARTH SCIENCE > TERRESTRIAL HYDROSPHERE > WATER QUALITY/WATER CHEMISTRY > WATER CHARACTERISTICS > EUTROPHICATION\",\n",
+    "                \"GCMDSK:EARTH SCIENCE SERVICES > MODELS > HYDROLOGIC AND TERRESTRIAL WATER CYCLE MODELS\",\n",
     "                \"GCMDLOC:CONTINENT > EUROPE > NORTHERN EUROPE > SCANDINAVIA > NORWAY\",\n",
     "            ]\n",
     "        ),\n",
@@ -195,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -574,20 +568,20 @@
        "    fab          (y, x) float32 3.403e+38 3.403e+38 ... 3.403e+38 3.403e+38\n",
        "    sswc         (y, x) float32 3.403e+38 3.403e+38 ... 3.403e+38 3.403e+38\n",
        "    veg          (y, x) float32 3.403e+38 3.403e+38 ... 3.403e+38 3.403e+38\n",
-       "Attributes: (12/33)\n",
-       "    title:                   Test dataset exceedence limits water and vegetat...\n",
-       "    summary:                 Exceedence limits for water using the SSWCoaa or...\n",
-       "    date_created:            2023-09-19 13:05:56.425192\n",
+       "Attributes: (12/34)\n",
+       "    title:                   Test dataset exceedances of critical loads for a...\n",
+       "    summary:                 Exceedances of critical loads for acidification ...\n",
+       "    date_created:            2023-09-21 09:31:44.280477\n",
        "    keywords:                GCMDSK:EARTH SCIENCE &gt; LAND SURFACE &gt; SOILS &gt; NI...\n",
        "    keywords_vocabulary:     GCMDSK:GCMD Science Keywords:https://gcmd.earthd...\n",
        "    time_coverage_start:     2017-01-01T00:00:00Z\n",
        "    ...                      ...\n",
-       "    publisher_email:         miljoinformatikk@niva.no\n",
        "    publisher_url:           https://niva.no\n",
        "    license:                 http://spdx.org/licenses/CC-BY-4.0(CC-BY-4.0)\n",
        "    iso_topic_category:      environment\n",
-       "    history:                 dscreator(2023-09-19 13:05:56.426631) reprojecte...\n",
-       "    references:              https://LINK_TO_REPORT.pdf</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-c3b4218c-8ff1-4b7c-8e92-81b8a9d939fd' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-c3b4218c-8ff1-4b7c-8e92-81b8a9d939fd' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>x</span>: 19821</li><li><span class='xr-has-index'>y</span>: 8628</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-f878b211-d084-432c-84d0-2c3d21205595' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f878b211-d084-432c-84d0-2c3d21205595' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-2.642 -2.64 -2.638 ... 33.29 33.29</div><input id='attrs-38fea650-33dc-420f-ab3d-7c05ee20eae5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-38fea650-33dc-420f-ab3d-7c05ee20eae5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d25bdec0-0d3a-4243-9c4a-ac924f2b75a0' class='xr-var-data-in' type='checkbox'><label for='data-d25bdec0-0d3a-4243-9c4a-ac924f2b75a0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>X</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([-2.641826, -2.640014, -2.638201, ..., 33.283793, 33.285605, 33.287418])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>72.55 72.55 72.54 ... 56.91 56.91</div><input id='attrs-b5a7483b-c2eb-4dde-8af9-0561002ca860' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b5a7483b-c2eb-4dde-8af9-0561002ca860' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-073f12e7-f67d-4213-a665-fc9eb891cda3' class='xr-var-data-in' type='checkbox'><label for='data-073f12e7-f67d-4213-a665-fc9eb891cda3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>Y</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([72.547465, 72.545652, 72.543839, ..., 56.912261, 56.910448, 56.908636])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-60c5e881-c9bc-453e-8e40-81e5b220ae57' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-60c5e881-c9bc-453e-8e40-81e5b220ae57' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-76d17d25-cbdd-405a-b50b-e5bb676c8f34' class='xr-var-data-in' type='checkbox'><label for='data-76d17d25-cbdd-405a-b50b-e5bb676c8f34' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>horizontal_datum_name :</span></dt><dd>World Geodetic System 1984</dd><dt><span>grid_mapping_name :</span></dt><dd>latitude_longitude</dd><dt><span>spatial_ref :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd><dt><span>GeoTransform :</span></dt><dd>-2.642732847538063 0.0018127772315066732 0.0 72.5483712678977 0.0 -0.0018127772315066732</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-ef249b12-e3b4-4f05-8d1e-7cc8c38f73d1' class='xr-section-summary-in' type='checkbox'  checked><label for='section-ef249b12-e3b4-4f05-8d1e-7cc8c38f73d1' class='xr-section-summary' >Data variables: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>fab</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>3.403e+38 3.403e+38 ... 3.403e+38</div><input id='attrs-a26e929b-4a1c-4367-935b-f084e935b3a7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a26e929b-4a1c-4367-935b-f084e935b3a7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-27560f51-c851-4bdc-8ffe-56cf8e8eeff5' class='xr-var-data-in' type='checkbox'><label for='data-27560f51-c851-4bdc-8ffe-56cf8e8eeff5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Acidification: First-order Acidity Balance</dd><dt><span>units :</span></dt><dd>mEkv/m^2/year</dd><dt><span>short_name :</span></dt><dd>fab</dd><dt><span>_FillValue :</span></dt><dd>3.402823466e+38</dd></dl></div><div class='xr-var-data'><pre>array([[3.4028235e+38, 3.4028235e+38, 3.4028235e+38, ..., 3.4028235e+38,\n",
+       "    history:                 dscreator(2023-09-21 09:31:44.281626) reprojecte...\n",
+       "    references:              https://LINK_TO_REPORT.pdf\n",
+       "    id:                      070defc3-dc6d-4055-b9de-d942219f46bb</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-5c8e6769-a4f6-494d-b54a-53a1adb9ed03' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-5c8e6769-a4f6-494d-b54a-53a1adb9ed03' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>x</span>: 19821</li><li><span class='xr-has-index'>y</span>: 8628</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-0fbbe85c-452b-443e-9d19-14028eecc01e' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0fbbe85c-452b-443e-9d19-14028eecc01e' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-2.642 -2.64 -2.638 ... 33.29 33.29</div><input id='attrs-6e93d090-1cb5-4f1e-b66f-5026b5b81298' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6e93d090-1cb5-4f1e-b66f-5026b5b81298' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ed00e15a-e3de-4f41-a6fe-9b7ddde09245' class='xr-var-data-in' type='checkbox'><label for='data-ed00e15a-e3de-4f41-a6fe-9b7ddde09245' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>X</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([-2.641826, -2.640014, -2.638201, ..., 33.283793, 33.285605, 33.287418])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>72.55 72.55 72.54 ... 56.91 56.91</div><input id='attrs-4c87c0a9-bebf-43c0-90b7-7c5979796699' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4c87c0a9-bebf-43c0-90b7-7c5979796699' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5ab6520e-940d-47da-89d9-4c2eb6063ed3' class='xr-var-data-in' type='checkbox'><label for='data-5ab6520e-940d-47da-89d9-4c2eb6063ed3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>Y</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([72.547465, 72.545652, 72.543839, ..., 56.912261, 56.910448, 56.908636])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-112a4801-9322-4aa7-b6f0-1636af5fe0c6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-112a4801-9322-4aa7-b6f0-1636af5fe0c6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1ae967a1-b959-415e-94e9-aa5df7d694d5' class='xr-var-data-in' type='checkbox'><label for='data-1ae967a1-b959-415e-94e9-aa5df7d694d5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>horizontal_datum_name :</span></dt><dd>World Geodetic System 1984</dd><dt><span>grid_mapping_name :</span></dt><dd>latitude_longitude</dd><dt><span>spatial_ref :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd><dt><span>GeoTransform :</span></dt><dd>-2.642732847538063 0.0018127772315066732 0.0 72.5483712678977 0.0 -0.0018127772315066732</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-4b1e812e-3729-4cab-8816-455ea510ad63' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4b1e812e-3729-4cab-8816-455ea510ad63' class='xr-section-summary' >Data variables: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>fab</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>3.403e+38 3.403e+38 ... 3.403e+38</div><input id='attrs-7fa2e3ce-0452-433d-99f2-d4a92790f171' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7fa2e3ce-0452-433d-99f2-d4a92790f171' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7ef82663-be30-4a5f-b1f3-3cee1af83519' class='xr-var-data-in' type='checkbox'><label for='data-7ef82663-be30-4a5f-b1f3-3cee1af83519' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Acidification: First-order Acidity Balance</dd><dt><span>units :</span></dt><dd>mEkv/m^2/year</dd><dt><span>short_name :</span></dt><dd>fab</dd><dt><span>_FillValue :</span></dt><dd>3.402823466e+38</dd></dl></div><div class='xr-var-data'><pre>array([[3.4028235e+38, 3.4028235e+38, 3.4028235e+38, ..., 3.4028235e+38,\n",
        "        3.4028235e+38, 3.4028235e+38],\n",
        "       [3.4028235e+38, 3.4028235e+38, 3.4028235e+38, ..., 3.4028235e+38,\n",
        "        3.4028235e+38, 3.4028235e+38],\n",
@@ -599,7 +593,7 @@
        "       [3.4028235e+38, 3.4028235e+38, 3.4028235e+38, ..., 3.4028235e+38,\n",
        "        3.4028235e+38, 3.4028235e+38],\n",
        "       [3.4028235e+38, 3.4028235e+38, 3.4028235e+38, ..., 3.4028235e+38,\n",
-       "        3.4028235e+38, 3.4028235e+38]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>sswc</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>3.403e+38 3.403e+38 ... 3.403e+38</div><input id='attrs-7ac557bb-c6fe-4a6a-bce2-af337dd86592' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7ac557bb-c6fe-4a6a-bce2-af337dd86592' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-989eeb8b-3e10-442a-96d1-e962b0578fb4' class='xr-var-data-in' type='checkbox'><label for='data-989eeb8b-3e10-442a-96d1-e962b0578fb4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Acidification: Steady-State Water Chemistry</dd><dt><span>units :</span></dt><dd>mEkv/m^2/year</dd><dt><span>short_name :</span></dt><dd>sswc</dd><dt><span>_FillValue :</span></dt><dd>3.402823466e+38</dd></dl></div><div class='xr-var-data'><pre>array([[3.4028235e+38, 3.4028235e+38, 3.4028235e+38, ..., 3.4028235e+38,\n",
+       "        3.4028235e+38, 3.4028235e+38]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>sswc</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>3.403e+38 3.403e+38 ... 3.403e+38</div><input id='attrs-fb21bd60-f5e7-4882-8043-1cf660ff0a7e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-fb21bd60-f5e7-4882-8043-1cf660ff0a7e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c29218a1-87fe-4e32-aac1-3af6772e9600' class='xr-var-data-in' type='checkbox'><label for='data-c29218a1-87fe-4e32-aac1-3af6772e9600' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Acidification: Steady-State Water Chemistry</dd><dt><span>units :</span></dt><dd>mEkv/m^2/year</dd><dt><span>short_name :</span></dt><dd>sswc</dd><dt><span>_FillValue :</span></dt><dd>3.402823466e+38</dd></dl></div><div class='xr-var-data'><pre>array([[3.4028235e+38, 3.4028235e+38, 3.4028235e+38, ..., 3.4028235e+38,\n",
        "        3.4028235e+38, 3.4028235e+38],\n",
        "       [3.4028235e+38, 3.4028235e+38, 3.4028235e+38, ..., 3.4028235e+38,\n",
        "        3.4028235e+38, 3.4028235e+38],\n",
@@ -611,7 +605,7 @@
        "       [3.4028235e+38, 3.4028235e+38, 3.4028235e+38, ..., 3.4028235e+38,\n",
        "        3.4028235e+38, 3.4028235e+38],\n",
        "       [3.4028235e+38, 3.4028235e+38, 3.4028235e+38, ..., 3.4028235e+38,\n",
-       "        3.4028235e+38, 3.4028235e+38]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>veg</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>3.403e+38 3.403e+38 ... 3.403e+38</div><input id='attrs-6c31c434-422c-4c08-acbb-352bc97922ba' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6c31c434-422c-4c08-acbb-352bc97922ba' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-754173e7-aea0-4f27-aaf7-55cf2dfa15c6' class='xr-var-data-in' type='checkbox'><label for='data-754173e7-aea0-4f27-aaf7-55cf2dfa15c6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Eutrophication</dd><dt><span>units :</span></dt><dd>mEkv/m^2/year</dd><dt><span>short_name :</span></dt><dd>veg</dd><dt><span>_FillValue :</span></dt><dd>3.402823466e+38</dd></dl></div><div class='xr-var-data'><pre>array([[3.4028235e+38, 3.4028235e+38, 3.4028235e+38, ..., 3.4028235e+38,\n",
+       "        3.4028235e+38, 3.4028235e+38]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>veg</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>3.403e+38 3.403e+38 ... 3.403e+38</div><input id='attrs-d14228e7-97e3-4b84-b651-6159370728f2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d14228e7-97e3-4b84-b651-6159370728f2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8a4a22bb-65a2-4203-bce6-1e90676758a3' class='xr-var-data-in' type='checkbox'><label for='data-8a4a22bb-65a2-4203-bce6-1e90676758a3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Eutrophication</dd><dt><span>units :</span></dt><dd>mEkv/m^2/year</dd><dt><span>short_name :</span></dt><dd>veg</dd><dt><span>_FillValue :</span></dt><dd>3.402823466e+38</dd></dl></div><div class='xr-var-data'><pre>array([[3.4028235e+38, 3.4028235e+38, 3.4028235e+38, ..., 3.4028235e+38,\n",
        "        3.4028235e+38, 3.4028235e+38],\n",
        "       [3.4028235e+38, 3.4028235e+38, 3.4028235e+38, ..., 3.4028235e+38,\n",
        "        3.4028235e+38, 3.4028235e+38],\n",
@@ -623,7 +617,7 @@
        "       [3.4028235e+38, 3.4028235e+38, 3.4028235e+38, ..., 3.4028235e+38,\n",
        "        3.4028235e+38, 3.4028235e+38],\n",
        "       [3.4028235e+38, 3.4028235e+38, 3.4028235e+38, ..., 3.4028235e+38,\n",
-       "        3.4028235e+38, 3.4028235e+38]], dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-0ffd1e06-a77f-414c-9eb2-aa3a3b924ddc' class='xr-section-summary-in' type='checkbox'  ><label for='section-0ffd1e06-a77f-414c-9eb2-aa3a3b924ddc' class='xr-section-summary' >Indexes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-dfba4b6d-2c60-4c29-b03c-0b7e700f3fe2' class='xr-index-data-in' type='checkbox'/><label for='index-dfba4b6d-2c60-4c29-b03c-0b7e700f3fe2' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([-2.6418264589223095, -2.6400136816908026, -2.6382009044592962,\n",
+       "        3.4028235e+38, 3.4028235e+38]], dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-5dc6f713-9a30-4973-a1da-9ebf919e9311' class='xr-section-summary-in' type='checkbox'  ><label for='section-5dc6f713-9a30-4973-a1da-9ebf919e9311' class='xr-section-summary' >Indexes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-b2ab9e7d-1110-4ea7-8e38-fbd68293457f' class='xr-index-data-in' type='checkbox'/><label for='index-b2ab9e7d-1110-4ea7-8e38-fbd68293457f' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([-2.6418264589223095, -2.6400136816908026, -2.6382009044592962,\n",
        "       -2.6363881272277894,  -2.634575349996283,  -2.632762572764776,\n",
        "       -2.6309497955332692,  -2.629137018301763,  -2.627324241070256,\n",
        "       -2.6255114638387496,\n",
@@ -632,7 +626,7 @@
        "        33.276541606150914,   33.27835438338242,   33.28016716061393,\n",
        "        33.281979937845435,   33.28379271507694,   33.28560549230845,\n",
        "        33.287418269539955],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;x&#x27;, length=19821))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-f4e898af-86eb-4ec0-af7f-579e4fe294c4' class='xr-index-data-in' type='checkbox'/><label for='index-f4e898af-86eb-4ec0-af7f-579e4fe294c4' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ 72.54746487928196,  72.54565210205045,  72.54383932481895,\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;x&#x27;, length=19821))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-5ec37433-e9ae-4bc2-b305-27a01215451a' class='xr-index-data-in' type='checkbox'/><label for='index-5ec37433-e9ae-4bc2-b305-27a01215451a' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ 72.54746487928196,  72.54565210205045,  72.54383932481895,\n",
        "        72.54202654758744,  72.54021377035593,  72.53840099312443,\n",
        "        72.53658821589292,  72.53477543866141,   72.5329626614299,\n",
        "         72.5311498841984,\n",
@@ -641,7 +635,7 @@
        "        56.91951236646293, 56.917699589231425,  56.91588681199992,\n",
        "        56.91407403476841, 56.912261257536905,   56.9104484803054,\n",
        "        56.90863570307389],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;y&#x27;, length=8628))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-9e2d1ea1-ae4e-45a8-aaef-5f40784ca551' class='xr-section-summary-in' type='checkbox'  ><label for='section-9e2d1ea1-ae4e-45a8-aaef-5f40784ca551' class='xr-section-summary' >Attributes: <span>(33)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>Test dataset exceedence limits water and vegetation 2017-2021</dd><dt><span>summary :</span></dt><dd>Exceedence limits for water using the SSWCoaa or FABoaa models, and vegetation using emperical derived data on the new deposition grid from Met.no.</dd><dt><span>date_created :</span></dt><dd>2023-09-19 13:05:56.425192</dd><dt><span>keywords :</span></dt><dd>GCMDSK:EARTH SCIENCE &gt; LAND SURFACE &gt; SOILS &gt; NITROGEN,GCMDSK:EARTH SCIENCE &gt; LAND SURFACE &gt; SOILS &gt; SULFUR,GCMDLOC:CONTINENT &gt; EUROPE &gt; NORTHERN EUROPE &gt; SCANDINAVIA &gt; NORWAY</dd><dt><span>keywords_vocabulary :</span></dt><dd>GCMDSK:GCMD Science Keywords:https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords,GCMDLOC:GCMD Locations:https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/locations</dd><dt><span>time_coverage_start :</span></dt><dd>2017-01-01T00:00:00Z</dd><dt><span>time_coverage_end :</span></dt><dd>2021-12-31T00:00:00Z</dd><dt><span>geospatial_lat_min :</span></dt><dd>56.90863570307389</dd><dt><span>geospatial_lat_max :</span></dt><dd>72.54746487928196</dd><dt><span>geospatial_lon_min :</span></dt><dd>-2.6418264589223095</dd><dt><span>geospatial_lon_max :</span></dt><dd>33.287418269539955</dd><dt><span>project :</span></dt><dd>Tålegrense</dd><dt><span>title_no :</span></dt><dd>Test dataset overskridelser av tålegrenser vann og vegetasjon 2017-2021</dd><dt><span>summary_no :</span></dt><dd>Overskridelser av tålegrenser for vann ved SSWCoaa or FABoaa modellene og vegetasjon ved empirisk data på nytt rutenett fra Met.no. </dd><dt><span>spatial_representation :</span></dt><dd>grid</dd><dt><span>naming_authority :</span></dt><dd>no.niva</dd><dt><span>creator_type :</span></dt><dd>institution</dd><dt><span>creator_institution :</span></dt><dd>Norwegian Institute for Water Research</dd><dt><span>institution :</span></dt><dd>Norwegian Institute for Water Research</dd><dt><span>institution_short_name :</span></dt><dd>NIVA</dd><dt><span>creator_email :</span></dt><dd>miljoinformatikk@niva.no</dd><dt><span>creator_url :</span></dt><dd>https://niva.no</dd><dt><span>data_owner :</span></dt><dd>Norwegian Institute for Water Research</dd><dt><span>processing_level :</span></dt><dd>Missing data has been filled with fillValue.</dd><dt><span>Conventions :</span></dt><dd>CF-1.7, ACDD-1.3</dd><dt><span>netcdf_version :</span></dt><dd>4</dd><dt><span>publisher_name :</span></dt><dd>Norwegian Institute for Water Research</dd><dt><span>publisher_email :</span></dt><dd>miljoinformatikk@niva.no</dd><dt><span>publisher_url :</span></dt><dd>https://niva.no</dd><dt><span>license :</span></dt><dd>http://spdx.org/licenses/CC-BY-4.0(CC-BY-4.0)</dd><dt><span>iso_topic_category :</span></dt><dd>environment</dd><dt><span>history :</span></dt><dd>dscreator(2023-09-19 13:05:56.426631) reprojected to EPSG:4326,populated metadata</dd><dt><span>references :</span></dt><dd>https://LINK_TO_REPORT.pdf</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;float64&#x27;, name=&#x27;y&#x27;, length=8628))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-60cc887e-6c1e-4b2c-80a6-efacacc37e2a' class='xr-section-summary-in' type='checkbox'  ><label for='section-60cc887e-6c1e-4b2c-80a6-efacacc37e2a' class='xr-section-summary' >Attributes: <span>(34)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>title :</span></dt><dd>Test dataset exceedances of critical loads for acidification and eutrophication 2017-2021</dd><dt><span>summary :</span></dt><dd>Exceedances of critical loads for acidification (water) using the SSWCoaa or FABoaa models and eutrophication (vegetation and water) using empirical critical loads</dd><dt><span>date_created :</span></dt><dd>2023-09-21 09:31:44.280477</dd><dt><span>keywords :</span></dt><dd>GCMDSK:EARTH SCIENCE &gt; LAND SURFACE &gt; SOILS &gt; NITROGEN,GCMDSK:EARTH SCIENCE &gt; LAND SURFACE &gt; SOILS &gt; SULFUR,GCMDSK:EARTH SCIENCE &gt; TERRESTRIAL HYDROSPHERE &gt; WATER QUALITY/WATER CHEMISTRY &gt; CONTAMINANTS &gt; ACID RAIN,GCMDSK:EARTH SCIENCE &gt; TERRESTRIAL HYDROSPHERE &gt; WATER QUALITY/WATER CHEMISTRY &gt; WATER CHARACTERISTICS &gt; EUTROPHICATION,GCMDSK:EARTH SCIENCE SERVICES &gt; MODELS &gt; HYDROLOGIC AND TERRESTRIAL WATER CYCLE MODELS,GCMDLOC:CONTINENT &gt; EUROPE &gt; NORTHERN EUROPE &gt; SCANDINAVIA &gt; NORWAY</dd><dt><span>keywords_vocabulary :</span></dt><dd>GCMDSK:GCMD Science Keywords:https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords,GCMDLOC:GCMD Locations:https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/locations</dd><dt><span>time_coverage_start :</span></dt><dd>2017-01-01T00:00:00Z</dd><dt><span>time_coverage_end :</span></dt><dd>2021-12-31T00:00:00Z</dd><dt><span>geospatial_lat_min :</span></dt><dd>56.90863570307389</dd><dt><span>geospatial_lat_max :</span></dt><dd>72.54746487928196</dd><dt><span>geospatial_lon_min :</span></dt><dd>-2.6418264589223095</dd><dt><span>geospatial_lon_max :</span></dt><dd>33.287418269539955</dd><dt><span>project :</span></dt><dd>Tålegrense</dd><dt><span>title_no :</span></dt><dd>Test dataset overskridelser av tålegrenser for forsuring og overgjødsling 2017-2021</dd><dt><span>summary_no :</span></dt><dd>Overskridelser av tålegrenser for forsuring (vann) med SSWCoaa- or FABoaa-modellene og eutrofiering (vegetasjon og vann) med empiriske tålegrenser</dd><dt><span>spatial_representation :</span></dt><dd>grid</dd><dt><span>naming_authority :</span></dt><dd>no.niva</dd><dt><span>creator_type :</span></dt><dd>institution</dd><dt><span>creator_institution :</span></dt><dd>Norwegian Institute for Water Research</dd><dt><span>institution :</span></dt><dd>Norwegian Institute for Water Research</dd><dt><span>institution_short_name :</span></dt><dd>NIVA</dd><dt><span>creator_email :</span></dt><dd>miljoinformatikk@niva.no</dd><dt><span>creator_url :</span></dt><dd>https://niva.no</dd><dt><span>data_owner :</span></dt><dd>Norwegian Institute for Water Research</dd><dt><span>processing_level :</span></dt><dd>Missing data has been filled with fillValue.</dd><dt><span>Conventions :</span></dt><dd>CF-1.7, ACDD-1.3</dd><dt><span>netcdf_version :</span></dt><dd>4</dd><dt><span>publisher_name :</span></dt><dd>Norwegian Institute for Water Research</dd><dt><span>publisher_email :</span></dt><dd>miljoinformatikk@niva.no</dd><dt><span>publisher_url :</span></dt><dd>https://niva.no</dd><dt><span>license :</span></dt><dd>http://spdx.org/licenses/CC-BY-4.0(CC-BY-4.0)</dd><dt><span>iso_topic_category :</span></dt><dd>environment</dd><dt><span>history :</span></dt><dd>dscreator(2023-09-21 09:31:44.281626) reprojected to EPSG:4326,populated metadata</dd><dt><span>references :</span></dt><dd>https://LINK_TO_REPORT.pdf</dd><dt><span>id :</span></dt><dd>070defc3-dc6d-4055-b9de-d942219f46bb</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -654,23 +648,23 @@
        "    fab          (y, x) float32 3.403e+38 3.403e+38 ... 3.403e+38 3.403e+38\n",
        "    sswc         (y, x) float32 3.403e+38 3.403e+38 ... 3.403e+38 3.403e+38\n",
        "    veg          (y, x) float32 3.403e+38 3.403e+38 ... 3.403e+38 3.403e+38\n",
-       "Attributes: (12/33)\n",
-       "    title:                   Test dataset exceedence limits water and vegetat...\n",
-       "    summary:                 Exceedence limits for water using the SSWCoaa or...\n",
-       "    date_created:            2023-09-19 13:05:56.425192\n",
+       "Attributes: (12/34)\n",
+       "    title:                   Test dataset exceedances of critical loads for a...\n",
+       "    summary:                 Exceedances of critical loads for acidification ...\n",
+       "    date_created:            2023-09-21 09:31:44.280477\n",
        "    keywords:                GCMDSK:EARTH SCIENCE > LAND SURFACE > SOILS > NI...\n",
        "    keywords_vocabulary:     GCMDSK:GCMD Science Keywords:https://gcmd.earthd...\n",
        "    time_coverage_start:     2017-01-01T00:00:00Z\n",
        "    ...                      ...\n",
-       "    publisher_email:         miljoinformatikk@niva.no\n",
        "    publisher_url:           https://niva.no\n",
        "    license:                 http://spdx.org/licenses/CC-BY-4.0(CC-BY-4.0)\n",
        "    iso_topic_category:      environment\n",
-       "    history:                 dscreator(2023-09-19 13:05:56.426631) reprojecte...\n",
-       "    references:              https://LINK_TO_REPORT.pdf"
+       "    history:                 dscreator(2023-09-21 09:31:44.281626) reprojecte...\n",
+       "    references:              https://LINK_TO_REPORT.pdf\n",
+       "    id:                      070defc3-dc6d-4055-b9de-d942219f46bb"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -691,7 +685,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -706,7 +700,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -723,7 +717,7 @@
        "'gs://nivatest-1-senda/datasets/exceedance-limits/fab-sswc-veg-exceedence/2017-2021_acdd_fab-sswc-veg-exceedence.nc'"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
Adds 3 GCMD keywords related to 
- [acidification](https://gcmd.earthdata.nasa.gov/KeywordViewer/scheme/all/62ee81e7-9f5a-4af5-a086-f4c402c7d19d?gtm_keyword=ACID%20RAIN&gtm_scheme=Earth%20Science)
- [eutrophication](https://gcmd.earthdata.nasa.gov/KeywordViewer/scheme/all/53d36c39-3cb1-44db-9746-feee86cbe9d7?gtm_keyword=EUTROPHICATION&gtm_scheme=Earth%20Science) and 
- [hydrologic model](https://gcmd.earthdata.nasa.gov/KeywordViewer/scheme/all/2eb094d5-70bc-49fa-acb6-4ad07f4c7b08?gtm_keyword=HYDROLOGIC%20AND%20TERRESTRIAL%20WATER%20CYCLE%20MODELS&gtm_scheme=Earth%20Science%20Services).

The model keyword is maybe not necessary. There is also [Dynamic Vegetation/Ecosystem Models](https://gcmd.earthdata.nasa.gov/KeywordViewer/scheme/all/adfee6d2-ca00-4f02-a570-5ccf0850cb55?gtm_keyword=DYNAMIC%20VEGETATION/ECOSYSTEM%20MODELS&gtm_scheme=Earth%20Science%20Services) keyword that might be more suitable.