### PR TITLE
Update sios project attr

### DIFF
--- a/dscreator/datasets/timeseries/sios.py
+++ b/dscreator/datasets/timeseries/sios.py
@@ -48,7 +48,7 @@ class SiosBuilder(TimeseriesDatasetBuilder):
             iso_topic_category="oceans",
             featureType=ds.attrs["featureType"],
             date_created=utils.iso_now(),
-            project=self.grouping,
+            project="SIOS InfraNOR (SIOS InfraNOR)",
             time_coverage_start=utils.to_isoformat(ds.time.min().values),
             time_coverage_end=utils.to_isoformat(ds.time.max().values),
             geospatial_lat_min=float(ds.latitude.min()),

--- a/dscreator/datasets/timeseries/sios.py
+++ b/dscreator/datasets/timeseries/sios.py
@@ -48,7 +48,7 @@ class SiosBuilder(TimeseriesDatasetBuilder):
             iso_topic_category="oceans",
             featureType=ds.attrs["featureType"],
             date_created=utils.iso_now(),
-            project="SIOS InfraNOR (SIOS InfraNOR)",
+            project="Svalbard Integrated Arctic Earth Observing System - Infrastructure development of the Norwegian node (SIOS InfraNOR)",
             time_coverage_start=utils.to_isoformat(ds.time.min().values),
             time_coverage_end=utils.to_isoformat(ds.time.max().values),
             geospatial_lat_min=float(ds.latitude.min()),


### PR DESCRIPTION
Updates the project attr for SIOS dataset. Seems like having the project acronym in brackets in the attribute adds it under Project in ADC (as e.g. for our [ferryboxes](https://adc.met.no/metsis/search?search_api_fulltext_op=and&fulltext=norwegian%20institute%20for%20water%20research&related_dataset_id=&start_date=&end_date=&bbox_op=intersects&bbox%5BminX%5D=&bbox%5BmaxX%5D=&bbox%5BmaxY%5D=&bbox%5BminY%5D=&items_per_page=15&f%5B0%5D=organisation%3ANorwegian%20Institute%20for%20Water%20Research)).

Shall we?
